### PR TITLE
Fixed  endless loop.

### DIFF
--- a/ZAA/10-Feb09/prg.cpp
+++ b/ZAA/10-Feb09/prg.cpp
@@ -15,7 +15,7 @@ int main( ) {
    ut.strcpy( cstring, greeting );
    cout << cstring << ", with length of " << size_t(greeting) << endl;
    // this will go to an endless loop, why?
-   for ( size_t i = greeting+5; i >= 0; i-- ) {
+   for ( size_t i = greeting+5; i != 0; i-- ) {
       cout << greeting[i];
    }
    cout << endl;


### PR DESCRIPTION
The code runs forever because of the loop condition i >= 0 in the for loop. The variable i is of type size_t, which only represents non-negative numbers.

When i reaches 0 and we decrement it, it doesn't become -1 as in regular integer types. Instead, it wraps around to a very large positive value. So, the condition i >= 0 always stays true, causing an infinite loop.

To fix this, I changed the loop condition to i != 0. This means the loop will continue until size_t i becomes 0. So after the change the loop stops correctly when i reach 0.